### PR TITLE
rpc-layer: Fix memory leak in call state pool

### DIFF
--- a/gck-rpc-module.c
+++ b/gck-rpc-module.c
@@ -1467,6 +1467,13 @@ static CK_RV rpc_C_Finalize(CK_VOID_PTR reserved)
 	if (ret != CKR_OK)
 		warning(("finalizing the daemon returned an error: %d", ret));
 
+	/* Cleanup the call state pool */
+	while (call_state_pool) {
+		cs = call_state_pool;
+		call_state_pool = cs->next;
+		call_destroy (cs);
+	}
+
 	/* This should stop all other calls in */
 	pkcs11_initialized = 0;
 	pkcs11_initialized_pid = 0;


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=684351