### PR TITLE
CMake: Fix install targets to respect the OS choices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,8 @@ if (WIN32)
 endif()
 
 # Install directives
-install(TARGETS pkcs11-proxy DESTINATION /lib)
-install(TARGETS pkcs11-daemon DESTINATION /bin)
+install(TARGETS pkcs11-proxy DESTINATION lib)
+install(TARGETS pkcs11-daemon DESTINATION bin)
 
 # Generate syscall-names.h using a custom command
 add_custom_command(


### PR DESCRIPTION
Without this, cmake install will forcibly install towards `/bin`, while there are (still) cases for which installing to `/usr/bin` makes sense (such as Debian packaging).